### PR TITLE
Fixing Set and Reset-DBODefaultSetting on Linux

### DIFF
--- a/functions/Reset-DBODefaultSetting.ps1
+++ b/functions/Reset-DBODefaultSetting.ps1
@@ -61,9 +61,19 @@ function Reset-DBODefaultSetting {
             }
         }
         elseif ($All) { $settings = Get-PSFConfig -Module dbops }
-        $newScope = switch ($Scope) {
-            'CurrentUser' { 'UserDefault' }
-            'AllUsers' { 'SystemDefault' }
+        $newScope = switch ($isWindows) {
+            $false {
+                switch ($Scope) {
+                    'CurrentUser' { 'FileUserLocal' }
+                    'AllUsers' { 'FileUserShared' }
+                }
+            }
+            default {
+                switch ($Scope) {
+                    'CurrentUser' { 'UserDefault' }
+                    'AllUsers' { 'SystemDefault' }
+                }
+            }
         }
         foreach ($config in $settings) {
             $sName = $config.fullName -replace '^dbops\.', ''

--- a/functions/Set-DBODefaultSetting.ps1
+++ b/functions/Set-DBODefaultSetting.ps1
@@ -72,9 +72,19 @@ function Set-DBODefaultSetting {
             Set-PSFConfig -Module dbops -Name $Name -Value $newValue -EnableException
         }
 
-        $newScope = switch ($Scope) {
-            'CurrentUser' { 'UserDefault' }
-            'AllUsers' { 'SystemDefault' }
+        $newScope = switch ($isWindows) {
+            $false {
+                switch ($Scope) {
+                    'CurrentUser' { 'FileUserLocal' }
+                    'AllUsers' { 'FileUserShared' }
+                }
+            }
+            default {
+                switch ($Scope) {
+                    'CurrentUser' { 'UserDefault' }
+                    'AllUsers' { 'SystemDefault' }
+                }
+            }
         }
         if (!$Temporary) {
             if ($PSCmdlet.ShouldProcess($Name, "Registering the value in the $newScope scope")) {


### PR DESCRIPTION
scope for linux was chosen incorrectly. Now it's chosen dynamically based on OS.