### PR TITLE
v0.6.4

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,5 @@
+# Release notes for v0.6.4:
+- ### Forcing the string datatype onto columns when -ReturnAsText is used (#115) by @nvarscar
 # Release notes for v0.6.3:
 - ### Adding hyphen to the variable token symbols (#112) by @nvarscar
 # Release notes for v0.6.2:

--- a/functions/Invoke-DBOQuery.ps1
+++ b/functions/Invoke-DBOQuery.ps1
@@ -75,7 +75,7 @@ function Invoke-DBOQuery {
         Specifies output type. Valid options for this parameter are 'DataSet', 'DataTable', 'DataRow', 'PSObject', and 'SingleValue'
 
     .PARAMETER ReturnAsText
-        Postgres only: returns all fields of the dataset as text values. This helps with the datatypes that are unknown to npgsql.
+        Converts all fields of the dataset to a string datatype. This helps with the datatypes that are unknown to connectivity libraries and can't be automatically converted.
 
     .PARAMETER Parameter
         Uses values in specified hashtable as parameters inside the SQL query.
@@ -369,10 +369,7 @@ function Invoke-DBOQuery {
                                         for ($j = 1; -not $name; $j++) {
                                             if ($table.Columns.ColumnName -notcontains "Column$j") { $name = "Column$j" }
                                         }
-                                        if ($datatype.FullName -eq 'System.DBNull') {
-                                            $datatype = [string]
-                                        }
-                                        elseif (!$datatype.FullName) {
+                                        if ($ReturnAsText -or $datatype.FullName -eq 'System.DBNull' -or -not $datatype.FullName) {
                                             $datatype = [string]
                                         }
                                         $null = $table.Columns.Add($name, $datatype)

--- a/tests/postgresql/Invoke-DBOQuery.Tests.ps1
+++ b/tests/postgresql/Invoke-DBOQuery.Tests.ps1
@@ -179,11 +179,12 @@ Describe "Invoke-DBOQuery PostgreSQL tests" -Tag $commandName, IntegrationTests 
             $result.b | Should -Be 3, 4
         }
         It "should select an unsupported datatype as text" {
-            $query = "select cast(null as aclitem[]) as a, cast('{=c/postgres}' as aclitem[]) as b"
+            $query = "select cast(null as aclitem[]) as a, cast('{=c/postgres}' as aclitem[]) as b, E'\\001'::bytea as c"
             $result = Invoke-DBOQuery -Query $query @connParams -As DataTable -ReturnAsText
-            $result.Columns.ColumnName | Should -Be @('a', 'b')
+            $result.Columns.ColumnName | Should -Be @('a', 'b', 'c')
             $result.a | Should -Be ([System.DBNull]::Value)
             $result.b | Should -Be '{=c/postgres}'
+            $result.c | Should -Be '\x01'
         }
     }
     Context "Negative tests" {


### PR DESCRIPTION
# Release notes for v0.6.4:
- ### Forcing the string datatype onto columns when -ReturnAsText is used (#115) by @nvarscar